### PR TITLE
Added error endpoint to fill up the heap with junk and cause an OOME.

### DIFF
--- a/src/main/java/org/cloudfoundry/samples/music/web/ErrorController.java
+++ b/src/main/java/org/cloudfoundry/samples/music/web/ErrorController.java
@@ -1,5 +1,8 @@
 package org.cloudfoundry.samples.music.web;
 
+import java.util.List;
+import java.util.ArrayList;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,11 +12,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/errors")
 public class ErrorController {
     private static final Logger logger = LoggerFactory.getLogger(ErrorController.class);
+    private List<int[]> junk = new ArrayList<>();
 
     @RequestMapping(value = "/kill")
     public void kill() {
         logger.info("Forcing application exit");
         System.exit(1);
+    }
+
+    @RequestMapping(value = "/fill-heap")
+    public void fillHeap() {
+        logger.info("Filling heap with junk, to initiate a crash");
+        while (true) {
+            junk.add(new int[9999999]);
+        }
     }
 
     @RequestMapping(value = "/throw")


### PR DESCRIPTION
This is useful for testing/demoing the `jvmkill` agent on CF.

Ex:  `curl http://spring-music.example.com/errors/fill-heap`

Output:

```
   2018-02-02T09:12:44.75-0500 [APP/PROC/WEB/0] OUT 2018-02-02 14:12:44.756  INFO 18 --- [nio-8080-exec-4] o.c.samples.music.web.ErrorController    : Filling heap with junk, to initiate a crash
   2018-02-02T09:12:46.06-0500 [APP/PROC/WEB/0] ERR Resource exhaustion event: the JVM was unable to allocate memory from the heap.
   2018-02-02T09:12:46.06-0500 [APP/PROC/WEB/0] ERR ResourceExhausted! (1/0)
   2018-02-02T09:12:46.72-0500 [APP/PROC/WEB/0] OUT | Instance Count | Total Bytes | Class Name                                                                                                       |
   2018-02-02T09:12:46.73-0500 [APP/PROC/WEB/0] OUT | 2312           | 240631904   | [I                                                                                                               |
   2018-02-02T09:12:46.73-0500 [APP/PROC/WEB/0] OUT | 74501          | 10819744    | [C                                                                                                               |
   2018-02-02T09:12:46.73-0500 [APP/PROC/WEB/0] OUT | 58254          | 1864128     | Ljava/util/concurrent/ConcurrentHashMap$Node;                                                                    |
...
  2018-02-02T09:12:46.89-0500 [APP/PROC/WEB/0] OUT Memory usage:
   2018-02-02T09:12:46.89-0500 [APP/PROC/WEB/0] OUT    Heap memory: init 339738624, used 271781840, committed 332922880, max 332922880
   2018-02-02T09:12:46.89-0500 [APP/PROC/WEB/0] OUT    Non-heap memory: init 2555904, used 90502344, committed 92823552, max 410075136
   2018-02-02T09:12:46.89-0500 [APP/PROC/WEB/0] OUT Memory pool usage:
   2018-02-02T09:12:46.89-0500 [APP/PROC/WEB/0] OUT    Code Cache: init 2555904, used 17378304, committed 18153472, max 251658240
   2018-02-02T09:12:46.90-0500 [APP/PROC/WEB/0] OUT    Metaspace: init 0, used 64922680, committed 66150400, max 135729152
   2018-02-02T09:12:46.90-0500 [APP/PROC/WEB/0] OUT    Compressed Class Space: init 0, used 8201584, committed 8519680, max 22687744
   2018-02-02T09:12:46.90-0500 [APP/PROC/WEB/0] OUT    PS Eden Space: init 84934656, used 81897336, committed 99614720, max 99614720
   2018-02-02T09:12:46.90-0500 [APP/PROC/WEB/0] OUT    PS Survivor Space: init 14155776, used 0, committed 6815744, max 6815744
   2018-02-02T09:12:46.90-0500 [APP/PROC/WEB/0] OUT    PS Old Gen: init 226492416, used 189884504, committed 226492416, max 226492416
   2018-02-02T09:12:46.90-0500 [APP/PROC/WEB/0] ERR jvmkill killing current process
   2018-02-02T09:12:46.90-0500 [APP/PROC/WEB/0] OUT 2018-02-02 14:12:46
   2018-02-02T09:12:46.90-0500 [APP/PROC/WEB/0] OUT Full thread dump OpenJDK 64-Bit Server VM (25.141-b15 mixed mode):
   2018-02-02T09:12:46.90-0500 [APP/PROC/WEB/0] OUT "DestroyJavaVM" #44 prio=5 os_prio=0 tid=0x00007fa67800b800 nid=0x39 waiting on condition [0x000
...
   2018-02-02T09:12:46.93-0500 [APP/PROC/WEB/0] OUT "GC task thread#2 (ParallelGC)" os_prio=0 tid=0x00007fa678024000 nid=0x3c runnable
   2018-02-02T09:12:46.93-0500 [APP/PROC/WEB/0] OUT "GC task thread#3 (ParallelGC)" os_prio=0 tid=0x00007fa678026000 nid=0x3d runnable
   2018-02-02T09:12:46.93-0500 [APP/PROC/WEB/0] OUT "VM Periodic Task Thread" os_prio=0 tid=0x00007fa6780c3800 nid=0x46 waiting on condition
   2018-02-02T09:12:46.95-0500 [APP/PROC/WEB/0] OUT JNI global references: 509259
   2018-02-02T09:12:46.96-0500 [APP/PROC/WEB/0] OUT Heap
   2018-02-02T09:12:46.96-0500 [APP/PROC/WEB/0] OUT  PSYoungGen      total 103936K, used 79977K [0x00000000f9400000, 0x0000000100000000, 0x0000000100000000)
   2018-02-02T09:12:46.96-0500 [APP/PROC/WEB/0] OUT   eden space 97280K, 82% used [0x00000000f9400000,0x00000000fe21a778,0x00000000ff300000)
   2018-02-02T09:12:46.96-0500 [APP/PROC/WEB/0] OUT   from space 6656K, 0% used [0x00000000ff300000,0x00000000ff300000,0x00000000ff980000)
   2018-02-02T09:12:46.96-0500 [APP/PROC/WEB/0] OUT   to   space 6656K, 0% used [0x00000000ff980000,0x00000000ff980000,0x0000000100000000)
   2018-02-02T09:12:46.96-0500 [APP/PROC/WEB/0] OUT  ParOldGen       total 221184K, used 185434K [0x00000000ebc00000, 0x00000000f9400000, 0x00000000f9400000)
   2018-02-02T09:12:46.96-0500 [APP/PROC/WEB/0] OUT   object space 221184K, 83% used [0x00000000ebc00000,0x00000000f7116858,0x00000000f9400000)
   2018-02-02T09:12:46.96-0500 [APP/PROC/WEB/0] OUT  Metaspace       used 63401K, capacity 63978K, committed 64600K, reserved 79500K
   2018-02-02T09:12:46.96-0500 [APP/PROC/WEB/0] OUT   class space    used 8009K, capacity 8165K, committed 8320K, reserved 22156K
   2018-02-02T09:12:51.90-0500 [APP/PROC/WEB/0] ERR jvmkill killing current process
...
   2018-02-02T09:12:51.97-0500 [APP/PROC/WEB/0] OUT Exit status 137
   2018-02-02T09:12:51.97-0500 [CELL/SSHD/0] OUT Exit status 0
   2018-02-02T09:12:52.12-0500 [API/1] OUT Process has crashed with type: "web"
   2018-02-02T09:12:52.12-0500 [CELL/0] OUT Stopping instance a6118cb5-a142-4399-505f-3d35
   2018-02-02T09:12:52.13-0500 [API/1] OUT App instance exited with guid 59b634a8-ccf2-4ba4-8f32-d9bf2bee127f payload: {"instance"=>"a6118cb5-a142-4399-505f-3d35", "index"=>0, "reason"=>"CRASHED", "exit_description"=>"APP/PROC/WEB: Exited with status 137", "crash_count"=>1, "crash_timestamp"=>1517580772111663036, "version"=>"6f0e7e5c-42bb-4477-b2f8-d4e682be611c"}
   2018-02-02T09:12:52.12-0500 [CELL/0] OUT Destroying container
   2018-02-02T09:12:52.29-0500 [CELL/0] OUT Creating container
   2018-02-02T09:12:52.76-0500 [CELL/0] OUT Successfully destroyed container
```