### PR TITLE
Fix Redis support by adding commons-pool2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     compile "org.springframework.cloud:spring-cloud-cloudfoundry-connector:${springCloudConnectorsVersion}"
 
     // JPA Persistence
+    runtime "org.apache.commons:commons-pool2:2.6.0"
     runtime "com.h2database:h2"
     runtime "mysql:mysql-connector-java"
     runtime "org.postgresql:postgresql"


### PR DESCRIPTION
You cannot bind a Redis service to a spring-music app instance, until you add a missing JAR dependency: commons-pool2.