### PR TITLE
Use ofNullable to build Optional with potential nulls

### DIFF
--- a/src/main/java/org/cloudfoundry/samples/music/repositories/redis/RedisAlbumRepository.java
+++ b/src/main/java/org/cloudfoundry/samples/music/repositories/redis/RedisAlbumRepository.java
@@ -47,7 +47,7 @@ public class RedisAlbumRepository implements CrudRepository<Album, String> {
 
     @Override
     public Optional<Album> findById(String id) {
-        return Optional.of(hashOps.get(ALBUMS_KEY, id));
+        return Optional.ofNullable(hashOps.get(ALBUMS_KEY, id));
     }
 
     @Override


### PR DESCRIPTION
If you search for something that doesn't exist, you get an NPE. 
I think the intent was to use Optional to cover when the hash lookup failed to find a result. 