### PR TITLE
Add support for serving H2C traffic

### DIFF
--- a/src/main/java/org/cloudfoundry/samples/music/config/data/H2cConfig.java
+++ b/src/main/java/org/cloudfoundry/samples/music/config/data/H2cConfig.java
@@ -1,0 +1,15 @@
+package org.cloudfoundry.samples.music.config.data;
+
+import org.apache.coyote.http2.Http2Protocol;
+
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class H2cConfig {
+    @Bean
+    public TomcatConnectorCustomizer customizer() {
+      return (connector) -> connector.addUpgradeProtocol(new Http2Protocol());
+    }
+}


### PR DESCRIPTION
Hello!

We are working on implementing HTTP/2 support for app routes on CF. See this [proposal](https://docs.google.com/document/d/1vcqlwchibRPnGn2pPQideaW8rmGMGoHFtgrS4RmsVl8/edit) for more details.

To that end, HTTP/2 apps will need to support H2C, since apps on CF do not terminate their own TLS. We would like to update Spring Music to support H2C for the following reasons:
1. As a development tool while we are building out this feature
2. As an example for Spring developers looking to update their apps to support HTTP/2 on CF

We based this implementation on this Spring Boot issue: https://github.com/spring-projects/spring-boot/issues/21997

Here is the root issue where we are tracking all changes related to this effort: cloudfoundry/routing-release#200

Thanks!