### PR TITLE
Add support for serving H2C traffic

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+server:
+  http2:
+    enabled: true
+
 spring:
   jpa:
     generate-ddl: true


### PR DESCRIPTION
Update `application.yml` to enable HTTP2 with H2C as long as
Java 11 is being used.