### PR TITLE
Adds an endpoint to echo back request information

### DIFF
--- a/src/main/java/org/cloudfoundry/samples/music/web/InfoController.java
+++ b/src/main/java/org/cloudfoundry/samples/music/web/InfoController.java
@@ -1,15 +1,20 @@
 package org.cloudfoundry.samples.music.web;
 
-import io.pivotal.cfenv.core.CfEnv;
-import io.pivotal.cfenv.core.CfService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.cloudfoundry.samples.music.domain.ApplicationInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
-import java.util.List;
+import io.pivotal.cfenv.core.CfEnv;
+import io.pivotal.cfenv.core.CfService;
 
 @RestController
 public class InfoController {
@@ -21,6 +26,17 @@ public class InfoController {
     public InfoController(Environment springEnvironment) {
         this.springEnvironment = springEnvironment;
         this.cfEnv = new CfEnv();
+    }
+
+    @RequestMapping(value = "/request")
+    public Map<String, String> requestInfo(HttpServletRequest req) {
+        HashMap<String, String> result = new HashMap<>();
+        result.put("session-id", req.getSession().getId());
+        result.put("protocol", req.getProtocol());
+        result.put("method", req.getMethod());
+        result.put("scheme", req.getScheme());
+        result.put("remote-addr", req.getRemoteAddr());
+        return result;
     }
 
     @RequestMapping(value = "/appinfo")


### PR DESCRIPTION
This is useful for troubleshooting and investigation. It is also useful to confirm that HTTP/2 is set up and working correctly.

Ex:

```
> curl https://spring-music-impressive-tiger-lq.apps.xiaomiorange.cf-app.com/request --http2 -s | jq .
{
  "protocol": "HTTP/1.1",
  "remote-addr": "198.51.100.100",
  "method": "GET",
  "scheme": "https",
  "session-id": "96C778F48E9AF18B6123430789E604CD"
}
```

Hmm, looks like HTTP/2 isn't set up correctly. 🤔 Oh, I forgot to enable it on my route.
