### PR TITLE
Note change needed to push to CF using Java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ After installing the 'cf' [command-line interface for Cloud Foundry](http://docs
 $ cf push
 ~~~
 
+Please note that if you built the app using Java 11, you will need to uncomment this line from `manifest.yml` as well:
+
+~~~
+#    JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'
+~~~
+
 The application will be pushed using settings in the provided `manifest.yml` file. The output from the command will show the URL that has been assigned to the application.
 
 ### Creating and binding services


### PR DESCRIPTION
Another developer and I ran into an issue where `cf push` failed with a message referring to jvm version mismatches. After some investigation, we discovered that we just needed to uncomment a single line in `manifest.yml`. It seems to me that it would be valuable to have that guidance up front, rather than forcing users to discover it. I suspect that many people are likely to just move on to another sample app if `cf push` fails unexpectedly like that.

The error we encountered:

~~~
ERR Exception in thread "main" java.lang.UnsupportedClassVersionError: org/cloudfoundry/samples/music/Application has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
~~~

I'm not sure if this readme modification is the best path, but I do think some kind of help for people using Java 11 would be valuable now, moreso as time goes on and more people are likely to have 11 installed on their machines.