### PR TITLE
Set project name & disable building jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,5 +77,5 @@ java {
 }
 
 jar {
-    archiveBaseName = "spring-music"
+    enabled = false
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "spring-music"


### PR DESCRIPTION
- Sets the root project name to 'spring-music', which in turn ensures that the produced JAR file will always have a consistent name not based on the enclosing folder.
- Disable building the 'plain' jar file so that only one JAR file is build when the project is compiled.
