### PR TITLE
Adds Cloud-Native buildpacks project.toml file

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,16 @@
+[project]
+id = "org.cloudfoundry.samples.spring-music"
+name = "Spring Music"
+
+[build]
+exclude = [
+    "/.git*",
+    "/build",
+    "/bin"
+]
+
+# disable the addition of spring-cloud-bindings by Paketo Cloud-Native buildpacks
+# spring-music is built to use CF Service bindings, not K8s service bindings
+[[build.env]]
+name = "BP_SPRING_CLOUD_BINDINGS_DISABLED"
+value = "true"


### PR DESCRIPTION
This PR adds a Cloud-Native buildpacks project.toml file, which is similar to manifest.yml in CF. This allows us to set some project metadata and a list of files/folders to be excluded from build.

We are also setting 'BP_SPRING_CLOUD_BINDINGS_DISABLED=true' so that Spring Cloud Bindings are not enabled when building with Cloud-Native buildpacks. This is because Spring Music is set up to build from CloudFoundry bound Services & 'VCAP_SERVICES'. This reduces the chance of there being a conflict, like on Korifi where both 'VCAP_SERVICES' and K8s service bindings are present.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>