### PR TITLE
Remove confusing MysqlDialect version

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,12 @@ management:
   endpoint:
     health:
       show-details: always
+#    configprops:
+#      show-values: always
+#      keys-to-sanitize:
+#    env:
+#      show-values: always
+#      keys-to-sanitize:
 
 ---
 spring:
@@ -31,10 +37,6 @@ spring:
     driver-class-name: com.mysql.jdbc.Driver
     username:
     password:
-  jpa:
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQL55Dialect
 
 ---
 spring:


### PR DESCRIPTION
* Spring Boot supposedly decides the best; verified using spring-music; removing the dialect fixed an issue with:
```
org.hibernate.boot.registry.selector.spi.StrategySelectionException: Unable to resolve name [org.hibernate.dialect.MySQL55Dialect] as strategy [org.hibernate.dialect.Dialect]
```
* Also put in comments helpful actuator params