### PR TITLE
Just use Java v 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The application use Spring Java configuration and [bean profiles](http://docs.sp
 
 ## Building
 
-This project requires Java version 17 or later to compile.
+This project requires Java version 17.
 
 > [!NOTE]
 > If you need to use an earlier Java version, check out the [`spring-boot-2` branch](https://github.com/cloudfoundry-samples/spring-music/tree/spring-boot-2), which can be built with Java 8 and later.  


### PR DESCRIPTION
While gradle 7.x.x will work with v 18 or v 19, it doesn't  make sense to suggest them since v17 is what will be used in CloudFoundry, and v18 and v19 were not long-term-support